### PR TITLE
Remove local references to packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,72 +1,72 @@
 appdirs==1.4.4
-astroid @ file:///C:/ci/astroid_1613501047216/work
-attrs @ file:///tmp/build/80754af9/attrs_1604765588209/work
+astroid
+attrs
 beautifulsoup4==4.9.3
 black==19.10b0
 brotlipy==0.7.0
 bs4==0.0.1
 certifi==2020.12.5
-cffi @ file:///C:/ci/cffi_1613247279197/work
-chardet @ file:///C:/ci/chardet_1607690654534/work
-click @ file:///home/linux1/recipes/ci/click_1610990599742/work
-colorama @ file:///tmp/build/80754af9/colorama_1607707115595/work
-cryptography @ file:///C:/ci/cryptography_1616769344312/work
+cffi
+chardet
+click
+colorama
+cryptography
 cycler==0.10.0
 Cython==0.29.14
 elasticsearch==7.11.0
-filelock @ file:///home/linux1/recipes/ci/filelock_1610993975404/work
+filelock
 gensim==3.8.3
-idna @ file:///home/linux1/recipes/ci/idna_1610986105248/work
-isort @ file:///tmp/build/80754af9/isort_1616355431277/work
+idna
+isort
 joblib==1.0.0
 kiwisolver==1.3.1
-lazy-object-proxy @ file:///C:/ci/lazy-object-proxy_1616529307648/work
+lazy-object-proxy
 lxml==4.6.2
 matplotlib==3.3.4
 mccabe==0.6.1
 mkl-fft==1.3.0
-mkl-random @ file:///C:/ci/mkl_random_1618854156666/work
+mkl-random
 mkl-service==2.3.0
 mypy-extensions==0.4.3
-nltk @ file:///tmp/build/80754af9/nltk_1618327084230/work
+nltk
 numpy==1.20.0
 olefile==0.46
-packaging @ file:///tmp/build/80754af9/packaging_1611952188834/work
+packaging
 pandas==1.2.1
 pathspec==0.7.0
 Pillow==8.1.0
 protobuf==3.14.0
-pycparser @ file:///tmp/build/80754af9/pycparser_1594388511720/work
-pylint @ file:///C:/ci/pylint_1617136058775/work
-pyOpenSSL @ file:///tmp/build/80754af9/pyopenssl_1608057966937/work
-pyparsing @ file:///home/linux1/recipes/ci/pyparsing_1610983426697/work
-PySocks @ file:///C:/ci/pysocks_1605287845585/work
+pycparser
+pylint
+pyOpenSSL
+pyparsing
+PySocks
 python-dateutil==2.8.1
 pytz==2021.1
-regex @ file:///C:/ci/regex_1617569893741/work
-requests @ file:///tmp/build/80754af9/requests_1608241421344/work
+regex
+requests
 sacremoses==0.0.43
 sarge==0.1.6
 scikit-learn==0.24.1
 scipy==1.6.0
 sentencepiece==0.1.95
-six @ file:///C:/ci/six_1605187374963/work
+six
 sklearn==0.0
 smart-open==5.0.0
 soupsieve==2.2
 threadpoolctl==2.1.0
 tokenizers==0.10.2
-toml @ file:///tmp/build/80754af9/toml_1616166611790/work
+toml
 torch==1.8.1
 torchaudio==0.8.1
 torchvision==0.9.1
 tqdm==4.56.0
 transformers~=4.1.1
 trectools==0.0.44
-typed-ast @ file:///C:/ci/typed-ast_1610466535590/work
-typing-extensions @ file:///home/ktietz/src/ci_mi/typing_extensions_1612808209620/work
+typed-ast
+typing-extensions
 urllib3==1.26.3
-win-inet-pton @ file:///C:/ci/win_inet_pton_1605306167264/work
+win-inet-pton
 wincertstore==0.2
 wrapt==1.12.1
 


### PR DESCRIPTION
If somebody runs "pip install -r requirements.txt" from the root
directory, he will be unsuccessful to install the project dependencies.
The reason is that there are multiple references for local packages.